### PR TITLE
Edits for Modal - Glossary Download / EDUGuides

### DIFF
--- a/wp-content/themes/it-gets-better/_assets/css/igb-styles.css
+++ b/wp-content/themes/it-gets-better/_assets/css/igb-styles.css
@@ -190,3 +190,37 @@ body {
   display: block;
   line-height: 1.1;
 }
+
+/* Styles for EDU Guide Popups */
+.modal-dialog.modal-lg {
+    width: 100%;
+}
+
+.theme-dark .modal .frm_forms .frm_form_fields > fieldset,
+.theme-light .modal .frm_forms .frm_form_fields > fieldset {
+    border: none;
+    box-shadow: none;
+    background: none;
+}
+
+.theme-dark .with_frm_style .frm_primary_label, .theme-dark .with_frm_style label {
+    color: white;
+}
+
+div#page {
+    z-index: 1;
+}
+
+div.modal.show {
+    display: flex !important;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.modal-header {
+    text-align: center;
+}
+
+h4.modal-title {
+    flex-grow: 1;
+}

--- a/wp-content/themes/it-gets-better/template-parts/loop/card-eduguide.php
+++ b/wp-content/themes/it-gets-better/template-parts/loop/card-eduguide.php
@@ -44,7 +44,7 @@ if( $eduguide_download ) {
   					$formidable_form_modal_anchor .= "<span class=\"file_size\">(&nbsp;";
   					$formidable_form_modal_anchor .= size_format( filesize( get_attached_file( $eduguide_download['ID'] ) ) );
   					$formidable_form_modal_anchor .= "&nbsp;)</span></a>";
-  					echo do_shortcode( '[frmmodal-content size="large" button_html="<a data-js-action=\'formidable-form-popup\' class=\'primary_button filetype-' . esc_attr( $eduguide_download_file_type ) . '\' href=\'' . esc_url( $eduguide_download_url ) . '\'>Download the EduGuide<span class=\'file_size\'>(&nbsp;' . size_format( filesize( get_attached_file( $eduguide_download['ID'] ) ) ) . '&nbsp;)</span></a>"]' . '[formidable id=6]' . '[/frmmodal-content]' );
+  					echo do_shortcode( '[frmmodal-content modal_title="Sign Up for Educational Resources" size="large" button_html="<a data-js-action=\'formidable-form-popup\' class=\'primary_button filetype-' . esc_attr( $eduguide_download_file_type ) . '\' href=\'' . esc_url( $eduguide_download_url ) . '\'>Download the EduGuide<span class=\'file_size\'>(&nbsp;' . size_format( filesize( get_attached_file( $eduguide_download['ID'] ) ) ) . '&nbsp;)</span></a>"]' . '[formidable id=6]' . '[/frmmodal-content]' );
           ?>
 				<?php endif;?>
 			</div>

--- a/wp-content/themes/it-gets-better/template-parts/singular/eduguide.php
+++ b/wp-content/themes/it-gets-better/template-parts/singular/eduguide.php
@@ -52,7 +52,7 @@ endif;
 				$formidable_form_modal_anchor .= "<span class=\"file_size\">(&nbsp;";
 				$formidable_form_modal_anchor .= size_format( filesize( get_attached_file( $eduguide_download['ID'] ) ) );
 				$formidable_form_modal_anchor .= "&nbsp;)</span></a>";
-				echo do_shortcode( '[frmmodal-content size="large" button_html="<a data-js-action=\'formidable-form-popup\' class=\'primary_button filetype-' . esc_attr( $eduguide_download_file_type ) . '\' href=\'' . esc_url( $eduguide_download_url ) . '\'>Download the EduGuide<span class=\'file_size\'>(&nbsp;' . size_format( filesize( get_attached_file( $eduguide_download['ID'] ) ) ) . '&nbsp;)</span></a>"]' . '[formidable id=6]' . '[/frmmodal-content]' );
+				echo do_shortcode( '[frmmodal-content size="large" modal_title="Sign Up for Educational Resources" button_html="<a data-js-action=\'formidable-form-popup\' class=\'primary_button filetype-' . esc_attr( $eduguide_download_file_type ) . '\' href=\'' . esc_url( $eduguide_download_url ) . '\'>Download the EduGuide<span class=\'file_size\'>(&nbsp;' . size_format( filesize( get_attached_file( $eduguide_download['ID'] ) ) ) . '&nbsp;)</span></a>"]' . '[formidable id=6]' . '[/frmmodal-content]' );
 			?>
 			<script type="text/javascript">
 			  document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
Made a few CSS edits and theme file edits for the Modal on the glossary/ page and the eduguides/ page.

NOTE: The igb-styles.css file is not being loaded on the site, so the CSS changes I made here are inside of the Customizer within WP Admin