### PR TITLE
Add OpenGraph image meta tag for "playlist" taxonomy.

### DIFF
--- a/wp-content/themes/it-gets-better/_assets/functions/seo.php
+++ b/wp-content/themes/it-gets-better/_assets/functions/seo.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Helpers for seo functionality
+ *
+ * @package It_Gets_Better
+ */
+
+/**
+ * Add "og:image" meta tag to head for "playlist" taxonomy.
+ *
+ * @return void
+ */
+function igb_seo_og_image() {
+	if ( is_tax( 'playlist' ) ) {
+		$term  = get_queried_object();
+		$image = get_field( 'header_image', $term );
+		if ( isset( $image ) ) {
+			echo '<meta property="og:image" content="' . esc_url( $image['url'] ) . '">';
+		}
+	}
+}
+add_action( 'wp_head', 'igb_seo_og_image' );

--- a/wp-content/themes/it-gets-better/functions.php
+++ b/wp-content/themes/it-gets-better/functions.php
@@ -190,3 +190,8 @@ require get_template_directory() . '/_assets/functions/woo.php';
  */
 require get_template_directory() . '/_assets/functions/block-mods.php';
 
+/**
+ * Functions for SEO
+ */
+require get_template_directory() . '/_assets/functions/seo.php';
+


### PR DESCRIPTION
Add OpenGraph image meta tag for the "playlist" taxonomy.
We are specifying the `header_image` field if set instead of letting Facebook guess the image.


## How to test:

Go to a playlist page eg.: https://itgetsbetter.org/playlist/passion-power-performance/
The `og:image` meta tag should be set with the header image URL in the HTML `<head>` tag
Facebook should use this image, can be tested using the [DB debug tool](https://developers.facebook.com/tools/debug/)